### PR TITLE
adding name attribute to metada.rb

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -1,3 +1,4 @@
+name             "service_discovery"
 maintainer       "Restorando S.A."
 maintainer_email "ops@restorando.com"
 license          "MIT"


### PR DESCRIPTION
berkshelf not working if matadata.rb miss 'name' attribute
