### PR TITLE
add default recipe with ip_finder including

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -1,0 +1,3 @@
+include_recipe 'ip_finder'
+
+::Chef::Recipe.send(:include, ServiceDiscovery::DSL)


### PR DESCRIPTION
service discovery can't find service if ip_finder gem was not installed
